### PR TITLE
Bugfix/lid references without vid 20241212

### DIFF
--- a/label.py
+++ b/label.py
@@ -64,6 +64,15 @@ def extract_product_ancillary(product_ancillary: bs4.Tag, checksum: str) -> Prod
     )
 
 
+def extract_product_context(product_context: bs4.Tag, checksum: str) -> ProductLabel:
+    """
+    Extracts keywords from the Product_Context element
+    """
+    return ProductLabel(
+        checksum=checksum,
+        identification_area=_extract(product_context.Identification_Area, _extract_identification_area)
+    )
+
 def extract_product_document(product_document: bs4.Tag, checksum: str) -> ProductLabel:
     """
     Extracts keywords from the Product_Document element

--- a/label.py
+++ b/label.py
@@ -73,6 +73,18 @@ def extract_product_context(product_context: bs4.Tag, checksum: str) -> ProductL
         identification_area=_extract(product_context.Identification_Area, _extract_identification_area)
     )
 
+
+def extract_product_schema(product_schema: bs4.Tag, checksum: str) -> ProductLabel:
+    """
+    Extracts keywords from the Product_Schema element
+    """
+    return ProductLabel(
+        checksum=checksum,
+        identification_area=_extract(product_schema.Identification_Area, _extract_identification_area),
+        file_areas=[_extract_file_area(f) for f in product_schema.find_all("File_Area_XML_Schema")]
+    )
+
+
 def extract_product_document(product_document: bs4.Tag, checksum: str) -> ProductLabel:
     """
     Extracts keywords from the Product_Document element

--- a/label.py
+++ b/label.py
@@ -21,7 +21,7 @@ def extract_collection(collection: bs4.Tag, checksum: str) -> ProductLabel:
         checksum=checksum,
         identification_area=_extract_identification_area(collection.Identification_Area),
         context_area=_extract_context_area(collection.Context_Area),
-        file_area=_extract_file_area(collection.File_Area_Inventory)
+        file_areas=[_extract_file_area(f) for f in collection.find_all("File_Area_Inventory")]
     )
 
 
@@ -34,7 +34,7 @@ def extract_bundle(bundle: bs4.Tag, checksum: str) -> ProductLabel:
         identification_area=_extract_identification_area(bundle.Identification_Area),
         context_area=_extract_context_area(bundle.Context_Area),
         bundle_member_entries=[_extract_bundle_member_entry(x) for x in bundle.find_all("Bundle_Member_Entry")],
-        file_area=_extract_file_area(bundle.File_Area_Text) if bundle.File_Area_Text else None
+        file_areas=[_extract_file_area(f) for f in bundle.find_all("File_Area_Text")]
     )
 
 
@@ -47,7 +47,7 @@ def extract_product_observational(product_observational: bs4.Tag, checksum: str)
         identification_area=_extract(product_observational.Identification_Area, _extract_identification_area),
         context_area=_extract(product_observational.Observation_Area, _extract_observation_area),
         discipline_area=_extract(product_observational.Discipline_Area, _extract_discipline_area),
-        file_area=_extract_file_area(product_observational.File_Area_Observational)
+        file_areas=[_extract_file_area(f) for f in product_observational.find_all("File_Area_Observational")]
     )
 
 
@@ -60,7 +60,7 @@ def extract_product_ancillary(product_ancillary: bs4.Tag, checksum: str) -> Prod
         identification_area=_extract(product_ancillary.Identification_Area, _extract_identification_area),
         context_area=_extract(product_ancillary.Context_Area, _extract_context_area),
         discipline_area=_extract(product_ancillary.Discipline_Area, _extract_discipline_area),
-        file_area=_extract_file_area(product_ancillary.File_Area_Ancillary)
+        file_areas=[_extract_file_area(f) for f in product_ancillary.find_all("File_Area_Ancillary")]
     )
 
 

--- a/labeltypes.py
+++ b/labeltypes.py
@@ -124,7 +124,7 @@ class BundleMemberEntry:
 class ProductLabel:
     checksum: str = None
     identification_area: IdentificationArea = None
-    file_area: Optional[FileArea] = None
+    file_areas: List[FileArea] = None
     context_area: Optional[ContextArea] = None
     discipline_area: Optional[DisciplineArea] = None
     document: Optional[Document] = None

--- a/lids.py
+++ b/lids.py
@@ -59,8 +59,12 @@ class LidVid:
 
     @staticmethod
     def parse(lidvidstr: str) -> 'LidVid':
-        lid, vid = lidvidstr.split("::")
-        return LidVid.assemble(lid, vid)
+        if "::" in lidvidstr:
+            lid, vid = lidvidstr.split("::")
+            return LidVid.assemble(lid, vid)
+        else:
+            lid = lidvidstr
+            return LidVid(lid=Lid.parse(lid), vid=Vid(-1, 0))
 
     @staticmethod
     def assemble(lid: str, vid: str) -> 'LidVid':

--- a/localclient.py
+++ b/localclient.py
@@ -15,7 +15,7 @@ from pds4 import CollectionProduct, BundleProduct, BasicProduct, CollectionInven
 def fetchcollection(path: str) -> CollectionProduct:
     """Retrieves a collection product located at the specified path"""
     collection_label = fetchlabel(path)
-    inventory_path = os.path.join(os.path.dirname(path), collection_label.file_area.file_name)
+    inventory_path = os.path.join(os.path.dirname(path), collection_label.file_areas[0].file_name)
     with open(inventory_path, newline="") as f:
         inventory = CollectionInventory.from_csv(f.read())
     return CollectionProduct(collection_label, inventory, label_path=path, inventory_path=inventory_path)
@@ -25,7 +25,7 @@ def fetchbundle(path: str) -> BundleProduct:
     """Retrieves a bundle product located at the specified path"""
     bundle_label = fetchlabel(path)
     dirname = os.path.dirname(path)
-    readme_path = os.path.join(dirname, bundle_label.file_area.file_name) if bundle_label.file_area else None
+    readme_path = os.path.join(dirname, bundle_label.file_areas[0].file_name) if bundle_label.file_areas else None
 
     return BundleProduct(bundle_label, label_path=path, readme_path=readme_path)
 
@@ -34,7 +34,7 @@ def fetchproduct(path: str) -> BasicProduct:
     """Retrieves a basic product located at the specified path"""
     product_label = fetchlabel(path)
     dirname = os.path.dirname(path)
-    data_paths = paths.rebase_filenames(dirname, [product_label.file_area.file_name]) if product_label.file_area else []
+    data_paths = paths.rebase_filenames(dirname, [f.file_name for f in product_label.file_areas]) if product_label.file_areas else []
     document_paths = paths.rebase_filenames(dirname, product_label.document.filenames()) if product_label.document else []
 
     return BasicProduct(product_label, label_path=path, data_paths=data_paths + document_paths)

--- a/product.py
+++ b/product.py
@@ -24,6 +24,8 @@ def extract_label(xmldoc: BeautifulSoup, checksum: str, filepath: str = '') -> P
         return label.extract_product_ancillary(xmldoc.Product_Ancillary, checksum)
     if xmldoc.Product_Context:
         return label.extract_product_context(xmldoc.Product_Context, checksum)
+    if xmldoc.Product_XML_Schema:
+        return label.extract_product_schema(xmldoc.Product_XML_Schema, checksum)
     if xmldoc.Product_Document:
         return label.extract_product_document(xmldoc.Product_Document, checksum)
     if xmldoc.Product_Collection:

--- a/product.py
+++ b/product.py
@@ -22,6 +22,8 @@ def extract_label(xmldoc: BeautifulSoup, checksum: str, filepath: str = '') -> P
         return label.extract_product_observational(xmldoc.Product_Observational, checksum)
     if xmldoc.Product_Ancillary:
         return label.extract_product_ancillary(xmldoc.Product_Ancillary, checksum)
+    if xmldoc.Product_Context:
+        return label.extract_product_context(xmldoc.Product_Context, checksum)
     if xmldoc.Product_Document:
         return label.extract_product_document(xmldoc.Product_Document, checksum)
     if xmldoc.Product_Collection:

--- a/ready.py
+++ b/ready.py
@@ -36,14 +36,18 @@ def do_checkready(previous_fullbundle: pds4.FullBundle,
     errors.extend(validator.check_bundle_against_previous(previous_fullbundle.bundles[0], delta_fullbundle.bundles[0]))
     errors.extend(validator.check_bundle_against_collections(delta_fullbundle.bundles[0], delta_fullbundle.collections))
 
-    for delta_collection in delta_fullbundle.collections:
-        new_collection_lid = delta_collection.label.identification_area.lidvid.lid
-        previous_collections = [x for x in previous_fullbundle.collections if
-                                x.label.identification_area.lidvid.lid == new_collection_lid]
-        if previous_collections:
-            previous_collection = previous_collections[0]
-            errors.extend(validator.check_collection_against_previous(previous_collection, delta_collection))
+    for collection in delta_fullbundle.collections + previous_fullbundle.collections:
+        errors.extend(validator.check_vid_presence(collection.inventory.products()))
 
-    errors.extend(validator.check_filename_consistency(previous_fullbundle.products, delta_fullbundle.products))
+    if not errors:
+        for delta_collection in delta_fullbundle.collections:
+            new_collection_lid = delta_collection.label.identification_area.lidvid.lid
+            previous_collections = [x for x in previous_fullbundle.collections if
+                                    x.label.identification_area.lidvid.lid == new_collection_lid]
+            if previous_collections:
+                previous_collection = previous_collections[0]
+                errors.extend(validator.check_collection_against_previous(previous_collection, delta_collection))
+
+        errors.extend(validator.check_filename_consistency(previous_fullbundle.products, delta_fullbundle.products))
 
     return errors

--- a/validator.py
+++ b/validator.py
@@ -116,8 +116,8 @@ def _check_bundle_increment(previous_bundle: label.ProductLabel, delta_bundle: l
                                for x in delta_bundle.bundle_member_entries
                                if x.livdid_reference]
 
-    errors.extend(_check_vid_presence(previous_collection_lidvids))
-    errors.extend(_check_vid_presence(delta_collection_lidvids))
+    errors.extend(check_vid_presence(previous_collection_lidvids))
+    errors.extend(check_vid_presence(delta_collection_lidvids))
 
     for next_collection_lidvid in delta_collection_lidvids:
         matching_lidvids = [x for x in previous_collection_lidvids if x.lid == next_collection_lidvid.lid]
@@ -134,7 +134,7 @@ def _check_bundle_increment(previous_bundle: label.ProductLabel, delta_bundle: l
 
     return errors
 
-def _check_vid_presence(lidvids: Iterable[LidVid]) -> Iterable[ValidationError]:
+def check_vid_presence(lidvids: Iterable[LidVid]) -> Iterable[ValidationError]:
     """
     Checl that a LIDVID actually has a VID. The parser is tolerant, and will return a negative VID if one isn't supplied
     :param lidvids: A list of LIDVIDs

--- a/validator.py
+++ b/validator.py
@@ -116,6 +116,9 @@ def _check_bundle_increment(previous_bundle: label.ProductLabel, delta_bundle: l
                                for x in delta_bundle.bundle_member_entries
                                if x.livdid_reference]
 
+    errors.extend(_check_vid_presence(previous_collection_lidvids))
+    errors.extend(_check_vid_presence(delta_collection_lidvids))
+
     for next_collection_lidvid in delta_collection_lidvids:
         matching_lidvids = [x for x in previous_collection_lidvids if x.lid == next_collection_lidvid.lid]
         if matching_lidvids:
@@ -130,6 +133,14 @@ def _check_bundle_increment(previous_bundle: label.ProductLabel, delta_bundle: l
             errors.append(ValidationError(f"{previous_collection_lidvid} does not have a corresponding LidVid in the new collection"))
 
     return errors
+
+def _check_vid_presence(lidvids: Iterable[LidVid]) -> Iterable[ValidationError]:
+    """
+    Checl that a LIDVID actually has a VID. The parser is tolerant, and will return a negative VID if one isn't supplied
+    :param lidvids: A list of LIDVIDs
+    :return: A list of validation errors
+    """
+    return (ValidationError(f"Vid not provided for {x.lid}") for x in lidvids if x.vid.major < 0)
 
 def _check_lidvid_increment(previous_lidvid: LidVid, delta_lidvid: LidVid, same=True, minor=True, major=True) -> List[ValidationError]:
     """


### PR DESCRIPTION
Fixes errors noticed by neese:
* Product_Context and Product_XML_Schema were not properly supported
* Missing VIDs in a collection inventory would fail instead of emitting an error