### PR TITLE
Bugfix/vid issues 20250213

### DIFF
--- a/labeledit.py
+++ b/labeledit.py
@@ -34,7 +34,10 @@ def inject_bundle_member_entries(labelpath: str, entries_to_add: Iterable[Bundle
 def _bundle_member_entry_to_element(entry: BundleMemberEntry):
     bundle_member_entry = etree.Element("Bundle_Member_Entry")
 
-    bundle_member_entry.append(_text_element("lidvid_reference", entry.lidvid_reference))
+    if entry.lidvid_reference:
+        bundle_member_entry.append(_text_element("lidvid_reference", entry.lidvid_reference))
+    if entry.lid_reference:
+        bundle_member_entry.append(_text_element("lid_reference", entry.lid_reference))
     bundle_member_entry.append(_text_element("member_status", entry.member_status))
     bundle_member_entry.append(_text_element("reference_type", entry.reference_type))
 

--- a/labeledit.py
+++ b/labeledit.py
@@ -23,7 +23,7 @@ def inject_bundle_member_entries(labelpath: str, entries_to_add: Iterable[Bundle
     bundle_member_entries = find_bundle(xmldoc)[0]
 
     for entry_to_add in entries_to_add:
-        logger.info(f"Adding collection {entry_to_add.livdid_reference}")
+        logger.info(f"Adding collection {entry_to_add.lidvid_reference}")
         bundle_member_entries.append(_bundle_member_entry_to_element(entry_to_add))
 
     etree.indent(xmldoc, space="    ")
@@ -34,7 +34,7 @@ def inject_bundle_member_entries(labelpath: str, entries_to_add: Iterable[Bundle
 def _bundle_member_entry_to_element(entry: BundleMemberEntry):
     bundle_member_entry = etree.Element("Bundle_Member_Entry")
 
-    bundle_member_entry.append(_text_element("lidvid_reference", entry.livdid_reference))
+    bundle_member_entry.append(_text_element("lidvid_reference", entry.lidvid_reference))
     bundle_member_entry.append(_text_element("member_status", entry.member_status))
     bundle_member_entry.append(_text_element("reference_type", entry.reference_type))
 

--- a/labeltypes.py
+++ b/labeltypes.py
@@ -119,6 +119,9 @@ class BundleMemberEntry:
     lid_reference: str = None
     lidvid_reference: str = None
 
+    def lidvid(self) -> lids.LidVid:
+        return lids.LidVid.parse(self.lidvid_reference if self.lidvid_reference else self.lid_reference)
+
 
 @dataclass()
 class ProductLabel:

--- a/labeltypes.py
+++ b/labeltypes.py
@@ -117,7 +117,7 @@ class BundleMemberEntry:
     member_status: str
     reference_type: str
     lid_reference: str = None
-    livdid_reference: str = None
+    lidvid_reference: str = None
 
 
 @dataclass()

--- a/ready.py
+++ b/ready.py
@@ -44,7 +44,7 @@ def report_errors(errors: list[validator.ValidationError], previous_bundle_direc
 def do_checkready(previous_fullbundle: pds4.FullBundle,
                   delta_fullbundle: pds4.FullBundle, jaxa: bool) -> List[validator.ValidationError]:
     errors = []
-    errors.extend(validator.check_bundle_against_previous(previous_fullbundle.bundles[0], delta_fullbundle.bundles[0], jaxa))
+    errors.extend(validator.check_bundle_against_previous(previous_fullbundle.bundles[0], delta_fullbundle.bundles[0], jaxa, previous_fullbundle.collections))
     errors.extend(validator.check_bundle_against_collections(delta_fullbundle.bundles[0], delta_fullbundle.collections))
 
     for collection in delta_fullbundle.collections + previous_fullbundle.collections:

--- a/superseder.py
+++ b/superseder.py
@@ -23,13 +23,13 @@ def get_missing_collections(previous_bundles: List[pds4.BundleProduct], delta_bu
         raise Exception(f"Too many delta bundles: {len(delta_bundles)}")
     delta_bundle = delta_bundles[0]
     matching_bundles = [x for x in previous_bundles if x.lidvid().lid == delta_bundle.lidvid().lid]
-    delta_collection_lids = [lids.LidVid.parse(x.livdid_reference).lid for x in delta_bundle.label.bundle_member_entries]
+    delta_collection_lids = [lids.LidVid.parse(x.lidvid_reference).lid for x in delta_bundle.label.bundle_member_entries]
     logger.info(f"Known collections LIDs: {delta_collection_lids}")
     if len(matching_bundles):
         latest_previous_bundle = sorted(matching_bundles, key=lambda x: x.lidvid().vid, reverse=True)[0]
         lids.dataclass()
         missing_collections = [x for x in latest_previous_bundle.label.bundle_member_entries
-                               if lids.LidVid.parse(x.livdid_reference).lid not in delta_collection_lids]
+                               if lids.LidVid.parse(x.lidvid_reference).lid not in delta_collection_lids]
         logger.info(f"JAXA: Found the following missing collections: {missing_collections}")
         return missing_collections
     return []

--- a/superseder.py
+++ b/superseder.py
@@ -23,13 +23,13 @@ def get_missing_collections(previous_bundles: List[pds4.BundleProduct], delta_bu
         raise Exception(f"Too many delta bundles: {len(delta_bundles)}")
     delta_bundle = delta_bundles[0]
     matching_bundles = [x for x in previous_bundles if x.lidvid().lid == delta_bundle.lidvid().lid]
-    delta_collection_lids = [lids.LidVid.parse(x.lidvid_reference).lid for x in delta_bundle.label.bundle_member_entries]
+    delta_collection_lids = [x.lidvid() for x in delta_bundle.label.bundle_member_entries]
     logger.info(f"Known collections LIDs: {delta_collection_lids}")
     if len(matching_bundles):
         latest_previous_bundle = sorted(matching_bundles, key=lambda x: x.lidvid().vid, reverse=True)[0]
         lids.dataclass()
         missing_collections = [x for x in latest_previous_bundle.label.bundle_member_entries
-                               if lids.LidVid.parse(x.lidvid_reference).lid not in delta_collection_lids]
+                               if x.lidvid() not in delta_collection_lids]
         logger.info(f"JAXA: Found the following missing collections: {missing_collections}")
         return missing_collections
     return []

--- a/superseder.py
+++ b/superseder.py
@@ -23,13 +23,13 @@ def get_missing_collections(previous_bundles: List[pds4.BundleProduct], delta_bu
         raise Exception(f"Too many delta bundles: {len(delta_bundles)}")
     delta_bundle = delta_bundles[0]
     matching_bundles = [x for x in previous_bundles if x.lidvid().lid == delta_bundle.lidvid().lid]
-    delta_collection_lids = [x.lidvid() for x in delta_bundle.label.bundle_member_entries]
+    delta_collection_lids = [x.lidvid().lid for x in delta_bundle.label.bundle_member_entries]
     logger.info(f"Known collections LIDs: {delta_collection_lids}")
     if len(matching_bundles):
         latest_previous_bundle = sorted(matching_bundles, key=lambda x: x.lidvid().vid, reverse=True)[0]
         lids.dataclass()
         missing_collections = [x for x in latest_previous_bundle.label.bundle_member_entries
-                               if x.lidvid() not in delta_collection_lids]
+                               if x.lidvid().lid not in delta_collection_lids]
         logger.info(f"JAXA: Found the following missing collections: {missing_collections}")
         return missing_collections
     return []

--- a/validator.py
+++ b/validator.py
@@ -1,3 +1,5 @@
+import operator
+
 import pds4
 import label
 import labeltypes
@@ -209,8 +211,9 @@ def _check_for_preserved_modification_history(previous_collection: label.Product
     """
     errors = []
     logger.info(f'Checking consistency of modification history for {delta_collection.identification_area.lidvid} against {previous_collection.identification_area.lidvid}')
-    previous_details = previous_collection.identification_area.modification_history.modification_details
-    delta_details = delta_collection.identification_area.modification_history.modification_details
+
+    previous_details = sorted(previous_collection.identification_area.modification_history.modification_details, key=operator.attrgetter("version_id"))
+    delta_details = sorted(delta_collection.identification_area.modification_history.modification_details, key=operator.attrgetter("version_id"))
 
     delta_lidvid = delta_collection.identification_area.lidvid
     prev_lidvid = previous_collection.identification_area.lidvid
@@ -219,6 +222,7 @@ def _check_for_preserved_modification_history(previous_collection: label.Product
     prev_vid = prev_lidvid.vid
 
     if len(delta_details) >= len(previous_details):
+
         pairs = zip(previous_details, delta_details[:len(previous_details)])
         for pair in pairs:
             errors.extend(_compare_modifcation_detail(pair, prev_lidvid, delta_lidvid))

--- a/validator.py
+++ b/validator.py
@@ -111,7 +111,7 @@ def _check_bundle_increment(previous_bundle: label.ProductLabel, delta_bundle: l
     errors.extend(_check_lidvid_increment(previous_bundle_lidvid, delta_bundle_lidvid, same=False))
 
     # verify that all collections are referenced by vid
-    for x in previous_bundle.bundle_member_entries + delta_bundle.bundle_member_entries:
+    for x in delta_bundle.bundle_member_entries:
         if not x.livdid_reference:
             errors.append(ValidationError(x.lid_reference + " is referenced by lid instead of lidvid", "non_lidvid_reference"))
 
@@ -123,7 +123,7 @@ def _check_bundle_increment(previous_bundle: label.ProductLabel, delta_bundle: l
                                if x.livdid_reference]
 
     # ensure that any declared LIDVIDs actually have a VID component
-    errors.extend(check_vid_presence(previous_collection_lidvids))
+    #errors.extend(check_vid_presence(previous_collection_lidvids))
     errors.extend(check_vid_presence(delta_collection_lidvids))
 
     # verify that all collections in the delta bundle also exist in the previous bundle

--- a/validator.py
+++ b/validator.py
@@ -112,15 +112,15 @@ def _check_bundle_increment(previous_bundle: label.ProductLabel, delta_bundle: l
 
     # verify that all collections are referenced by vid
     for x in delta_bundle.bundle_member_entries:
-        if not x.livdid_reference:
+        if not x.lidvid_reference:
             errors.append(ValidationError(x.lid_reference + " is referenced by lid instead of lidvid", "non_lidvid_reference"))
 
-    previous_collection_lidvids = [LidVid.parse(x.livdid_reference)
-                        for x in previous_bundle.bundle_member_entries
-                        if x.livdid_reference]
-    delta_collection_lidvids = [LidVid.parse(x.livdid_reference)
-                               for x in delta_bundle.bundle_member_entries
-                               if x.livdid_reference]
+    previous_collection_lidvids = [LidVid.parse(x.lidvid_reference)
+                                   for x in previous_bundle.bundle_member_entries
+                                   if x.lidvid_reference]
+    delta_collection_lidvids = [LidVid.parse(x.lidvid_reference)
+                                for x in delta_bundle.bundle_member_entries
+                                if x.lidvid_reference]
 
     # ensure that any declared LIDVIDs actually have a VID component
     #errors.extend(check_vid_presence(previous_collection_lidvids))
@@ -261,7 +261,7 @@ def _check_bundle_for_latest_collections(bundle: labeltypes.ProductLabel, collec
     """
     logger.info(f'Checking collections references in {bundle.identification_area.lidvid}')
     errors = []
-    bundle_member_lidvids = set(LidVid.parse(e.livdid_reference) for e in bundle.bundle_member_entries)
+    bundle_member_lidvids = set(LidVid.parse(e.lidvid_reference) for e in bundle.bundle_member_entries)
 
     errors.extend(ValidationError(f"{c} not found in bundle member entry list", "collection_not_declared") for c in collection_lidvids - bundle_member_lidvids)
     errors.extend(ValidationError(f"{b} was declared, but no collection is present", "declared collection not found", "warning") for b in bundle_member_lidvids - collection_lidvids)

--- a/validator.py
+++ b/validator.py
@@ -115,15 +115,11 @@ def _check_bundle_increment(previous_bundle: label.ProductLabel, delta_bundle: l
         if not x.lidvid_reference:
             errors.append(ValidationError(x.lid_reference + " is referenced by lid instead of lidvid", "non_lidvid_reference"))
 
-    previous_collection_lidvids = [LidVid.parse(x.lidvid_reference)
-                                   for x in previous_bundle.bundle_member_entries
-                                   if x.lidvid_reference]
-    delta_collection_lidvids = [LidVid.parse(x.lidvid_reference)
-                                for x in delta_bundle.bundle_member_entries
-                                if x.lidvid_reference]
+    previous_collection_lidvids = [x.lidvid() for x in previous_bundle.bundle_member_entries]
+    delta_collection_lidvids = [x.lidvid() for x in delta_bundle.bundle_member_entries]
 
     # ensure that any declared LIDVIDs actually have a VID component
-    errors.extend(check_vid_presence(previous_collection_lidvids))
+    #errors.extend(check_vid_presence(previous_collection_lidvids))
     errors.extend(check_vid_presence(delta_collection_lidvids))
 
     # verify that all collections in the delta bundle also exist in the previous bundle
@@ -165,11 +161,12 @@ def _check_lidvid_increment(previous_lidvid: LidVid, delta_lidvid: LidVid, same=
     """
     logger.info(f'Checking increment of {delta_lidvid} against {previous_lidvid}')
     errors = []
-    allowed = ([previous_lidvid] if same else []) + \
-              ([previous_lidvid.inc_minor()] if minor else []) + \
-              ([previous_lidvid.inc_major()] if major else [])
-    if delta_lidvid not in allowed:
-        errors.append(ValidationError(f"Invalid lidvid: {delta_lidvid}. Must be one of {[x.__str__() for x in allowed]}", "incorrectly_incremented_lidvid"))
+    if previous_lidvid.vid.major > 0:
+        allowed = ([previous_lidvid] if same else []) + \
+                  ([previous_lidvid.inc_minor()] if minor else []) + \
+                  ([previous_lidvid.inc_major()] if major else [])
+        if delta_lidvid not in allowed:
+            errors.append(ValidationError(f"Invalid lidvid: {delta_lidvid}. Must be one of {[x.__str__() for x in allowed]}", "incorrectly_incremented_lidvid"))
     return errors
 
 

--- a/validator.py
+++ b/validator.py
@@ -123,7 +123,7 @@ def _check_bundle_increment(previous_bundle: label.ProductLabel, delta_bundle: l
                                 if x.lidvid_reference]
 
     # ensure that any declared LIDVIDs actually have a VID component
-    #errors.extend(check_vid_presence(previous_collection_lidvids))
+    errors.extend(check_vid_presence(previous_collection_lidvids))
     errors.extend(check_vid_presence(delta_collection_lidvids))
 
     # verify that all collections in the delta bundle also exist in the previous bundle

--- a/validator.py
+++ b/validator.py
@@ -261,7 +261,7 @@ def _check_bundle_for_latest_collections(bundle: labeltypes.ProductLabel, collec
     """
     logger.info(f'Checking collections references in {bundle.identification_area.lidvid}')
     errors = []
-    bundle_member_lidvids = set(LidVid.parse(e.lidvid_reference) for e in bundle.bundle_member_entries)
+    bundle_member_lidvids = set(e.lidvid() for e in bundle.bundle_member_entries)
 
     errors.extend(ValidationError(f"{c} not found in bundle member entry list", "collection_not_declared") for c in collection_lidvids - bundle_member_lidvids)
     errors.extend(ValidationError(f"{b} was declared, but no collection is present", "declared collection not found", "warning") for b in bundle_member_lidvids - collection_lidvids)


### PR DESCRIPTION
Updated MADI to handle previous bundles that have collections that are referenced only by LID.

MADI will now load information from the previous collection if it's available.
If there is no delta collection, then the bundle member entry in the integrated collection will have the VID of the collection that was present in the previous collection.

If there is no previous collection, and there is a new collection with a LIDVID reference, the delta VID will always be valid.

Otherwise, the lid refrence will propagate through to the integrated collection. This should only happen for secondary collections referenced by LID.
