### PR TITLE
Bugfix/orex tagcams 20250318

### DIFF
--- a/bundleloader.py
+++ b/bundleloader.py
@@ -1,3 +1,5 @@
+import os.path
+
 import localclient
 import logging
 import pds4
@@ -46,7 +48,7 @@ def is_collection(filepath: str) -> bool:
     :param filepath:
     :return:
     """
-    return "collection" in filepath
+    return os.path.basename(filepath).startswith("collection")
 
 
 def is_bundle(filepath: str) -> bool:
@@ -55,7 +57,7 @@ def is_bundle(filepath: str) -> bool:
     :param filepath:
     :return:
     """
-    return "bundle" in filepath
+    return os.path.basename(filepath).startswith("bundle")
 
 
 def is_superseded(filepath: str) -> bool:

--- a/localclient.py
+++ b/localclient.py
@@ -20,9 +20,14 @@ def fetchcollection(path: str) -> CollectionProduct:
     logger.debug(f"Parsing collection: {path}")
     collection_label = fetchlabel(path)
     inventory_path = os.path.join(os.path.dirname(path), collection_label.file_areas[0].file_name)
-    with open(inventory_path, newline="") as f:
-        logger.debug(f"Parsing collection inventory: {inventory_path}")
-        inventory = CollectionInventory.from_csv(f.read())
+    if "SUPERSEDED" in path:
+        logger.debug(f"Skipping inventory for superseded product: {inventory_path}")
+        inventory = None
+    else:
+        with open(inventory_path, newline="") as f:
+            logger.debug(f"Parsing collection inventory: {inventory_path}")
+            inventory = CollectionInventory.from_csv(f.read())
+
     return CollectionProduct(collection_label, inventory, label_path=path, inventory_path=inventory_path)
 
 

--- a/localclient.py
+++ b/localclient.py
@@ -1,6 +1,7 @@
 import hashlib
 import itertools
 import os
+import logging
 from typing import Iterable
 
 import bs4
@@ -11,12 +12,16 @@ from labeltypes import ProductLabel
 
 from pds4 import CollectionProduct, BundleProduct, BasicProduct, CollectionInventory
 
+logger = logging.getLogger(__name__)
+
 
 def fetchcollection(path: str) -> CollectionProduct:
     """Retrieves a collection product located at the specified path"""
+    logger.debug(f"Parsing collection: {path}")
     collection_label = fetchlabel(path)
     inventory_path = os.path.join(os.path.dirname(path), collection_label.file_areas[0].file_name)
     with open(inventory_path, newline="") as f:
+        logger.debug(f"Parsing collection inventory: {inventory_path}")
         inventory = CollectionInventory.from_csv(f.read())
     return CollectionProduct(collection_label, inventory, label_path=path, inventory_path=inventory_path)
 

--- a/pds4.py
+++ b/pds4.py
@@ -55,7 +55,7 @@ class CollectionInventory:
         if lid in self.items:
             previous = self.items[lid]
             if previous.lidvid.vid >= item.lidvid.vid:
-                raise Exception("Product is not newer than the version that already exists in the inventory")
+                raise Exception(f"Product {item.lidvid} is not newer than the version that already exists in the inventory {previous.lidvid}")
         self.items[lid] = item
 
     def products(self) -> set[LidVid]:

--- a/validator.py
+++ b/validator.py
@@ -222,6 +222,14 @@ def _check_for_modification_history(lbl: label.ProductLabel) -> List[ValidationE
 
     return errors
 
+
+def _extract_vid(m: labeltypes.ModificationDetail) -> Tuple[int, int]:
+    tokens = m.version_id.split(".")
+    if len(tokens):
+        return int(tokens[0]), int(tokens[1])
+    raise Exception(f"Could not parse vid: {m.version_id}")
+
+
 def _check_for_preserved_modification_history(previous_collection: label.ProductLabel,
                                               delta_collection: label.ProductLabel) -> List[ValidationError]:
     """
@@ -230,8 +238,8 @@ def _check_for_preserved_modification_history(previous_collection: label.Product
     errors = []
     logger.info(f'Checking consistency of modification history for {delta_collection.identification_area.lidvid} against {previous_collection.identification_area.lidvid}')
 
-    previous_details = sorted(previous_collection.identification_area.modification_history.modification_details, key=operator.attrgetter("version_id"))
-    delta_details = sorted(delta_collection.identification_area.modification_history.modification_details, key=operator.attrgetter("version_id"))
+    previous_details = sorted(previous_collection.identification_area.modification_history.modification_details, key=_extract_vid)
+    delta_details = sorted(delta_collection.identification_area.modification_history.modification_details, key=_extract_vid)
 
     delta_lidvid = delta_collection.identification_area.lidvid
     prev_lidvid = previous_collection.identification_area.lidvid


### PR DESCRIPTION
Updates to accomodate tagcams. The primary update is to ensure that files that happen to contain the word collection in the path aren't treated as collection products. I've changed it to check that the base name starts with collection. This should be safe enough, since collection should be a reserved word.

I've also given bundle labels the same treatment.

A secondary issue that I worked around is when already-superseded collection inventories are invalid. I've resolved this by not loading the inventory at all, since they are not used for already-superseded collectionsl