### PR TITLE
nonstandard_lidvid_increment needs to be a warning

### DIFF
--- a/validator.py
+++ b/validator.py
@@ -194,7 +194,7 @@ def _check_lidvid_increment(previous_lidvid: LidVid, delta_lidvid: LidVid, same=
             if warn:
                 errors.append(
                     ValidationError(f"Unusual lidvid: {delta_lidvid}. Should be one of {[x.__str__() for x in allowed]}, but may be different for secondary members",
-                                    "nonstandard_lidvid_increment"))
+                                    "nonstandard_lidvid_increment", "warning"))
             else:
                 errors.append(ValidationError(f"Invalid lidvid: {delta_lidvid}. Must be one of {[x.__str__() for x in allowed]}", "incorrectly_incremented_lidvid"))
     return errors


### PR DESCRIPTION
Completed previous fix for https://github.com/PSI-edu/madi/issues/22

Added the scaffolding, but forgot to make the new warning a warning, so it was still reporting as an error.

https://github.com/PSI-edu/madi/pull/23.